### PR TITLE
Fix a problem with scope detection and query parameters.

### DIFF
--- a/lib/AWS/Signature4.pm
+++ b/lib/AWS/Signature4.pm
@@ -240,6 +240,9 @@ sub _scope {
     } elsif ($host =~ /^(\w+)[-.]([\w-]+)\.amazonaws\.com/) {
 	$service  = $1;
 	$region ||= $2;
+    } elsif ($host =~ /^([\w-]+)\.([\w-]+)\.amazonaws\.com/) {
+	$service  = $1;
+	$region ||= $2;
     } elsif ($host =~ /^([\w-]+)\.amazonaws\.com/) {
 	$service = $1;
 	$region  = 'us-east-1';

--- a/t/01.basic.t
+++ b/t/01.basic.t
@@ -6,7 +6,7 @@
 use strict;
 use ExtUtils::MakeMaker;
 use FindBin '$Bin';
-use constant TEST_COUNT => 11;
+use constant TEST_COUNT => 12;
 
 use lib "$Bin/lib","$Bin/../lib","$Bin/../blib/lib","$Bin/../blib/arch";
 
@@ -43,6 +43,16 @@ is($signer->signed_url($url),$expected,'signed url from url correct (1)');
 
 $url = 'https://iam.amazonaws.com?Action=ListUsers&Version=2010-05-08&Date=20140101T060000Z';
 is($signer->signed_url($url),$expected,'signed url from url correct (2)');
+
+
+
+
+my $request = POST('https://cognito-identity.us-east-1.amazonaws.com',
+		   Date    => '1 January 2014 01:00:00 -0500');
+
+$signer->sign($request);
+
+is($request->header('Authorization'),'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20140101/us-east-1/cognito-identity/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=047c9335c6a34448efc59c2a1813711602e208dcb42ae95cd3b881bd4d91b194');
 
 exit 0;
 


### PR DESCRIPTION
Scope detection fails for the Amazon Cognito endpoint of: https://cognito-identity.us-east-1.amazonaws.com The code didn't parse it correctly so adjust the parsing and add a test.

Fix bug with signature calculate for query string parameters. Parameters passed in the query string like ?acl don't get properly included in the canonical request, this code fixes that problem. URI's query_form doesn't return these parameters.
