### PR TITLE
Add unassigned query param to canonical hash

### DIFF
--- a/lib/AWS/Signature4.pm
+++ b/lib/AWS/Signature4.pm
@@ -309,10 +309,16 @@ sub _hash_canonical_request {
 
     # canonicalize query string
     my %canonical;
-    while (my ($key,$value) = splice(@params,0,2)) {
-	$key   = uri_escape($key);
-	$value = uri_escape($value);
-	push @{$canonical{$key}},$value;
+    if ($uri->query && ! scalar @params) {
+        # We have the query param without assigned value (i.e. /?acl), so assign an empty value to it
+        $canonical{uri_escape($uri->query)} = [''];
+    }
+    else {
+        while (my ($key,$value) = splice(@params,0,2)) {
+            $key   = uri_escape($key);
+            $value = uri_escape($value);
+            push @{$canonical{$key}},$value;
+        }
     }
     my $canonical_query_string = join '&',map {my $key = $_; map {"$key=$_"} sort @{$canonical{$key}}} sort keys %canonical;
 


### PR DESCRIPTION
Hello Lincoln.

This is the fix for the query parser when the library performs the "canonicalization" of the query parameters.

In case we have the query param without assigned value (i.e. [/?acl](http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETacl.html)   ), AWS expects it in CanonicalQueryString in the form:
`acl=` 
and we should assign an empty value to it.

Please consider this change for your review. Thank you!

